### PR TITLE
added ability to override vagrantfile

### DIFF
--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/vagrant/VagrantContext.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/vagrant/VagrantContext.java
@@ -40,7 +40,8 @@ public class VagrantContext extends VMRunnerContext {
     File path;
     if (StringUtil.isEmptyOrSpaces(file)) {
       path = new File(myContext.getBuild().getCheckoutDirectory(), VMConstants.VAGRANT_FILE);
-      if (!path.isFile()) throw new RunBuildException(VMConstants.VAGRANT_FILE + " is not found at " + getCheckoutDirectory());
+      if (!path.isFile())
+        throw new RunBuildException(VMConstants.VAGRANT_FILE + " is not found at " + getCheckoutDirectory());
 
     } else {
       path = resolvePath(file);
@@ -55,5 +56,16 @@ public class VagrantContext extends VMRunnerContext {
 
     if (!path.isFile()) throw new RunBuildException("Vagrant file '" + file + "' does not exist");
     return path;
+  }
+
+  @NotNull
+  public boolean getRequiresCustomFile() {
+    String requiresCustomFile = myContext.getRunnerParameters().get(VMConstants.PARAMETER_VAGRANTFILE_FULL_OVERRIDE);
+    return requiresCustomFile != null && requiresCustomFile.equals("yes");
+  }
+
+  @NotNull
+  public String getCustomVagrantfileContent() {
+    return myContext.getRunnerParameters().get(VMConstants.PARAMETER_VAGRANTFILE_CUSTOM_CONTENT);
   }
 }

--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/vagrant/VagrantContext.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/vagrant/VagrantContext.java
@@ -59,12 +59,6 @@ public class VagrantContext extends VMRunnerContext {
   }
 
   @NotNull
-  public boolean getRequiresCustomFile() {
-    String requiresCustomFile = myContext.getRunnerParameters().get(VMConstants.PARAMETER_VAGRANTFILE_FULL_OVERRIDE);
-    return requiresCustomFile != null && requiresCustomFile.equals("yes");
-  }
-
-  @NotNull
   public String getCustomVagrantfileContent() {
     return myContext.getRunnerParameters().get(VMConstants.PARAMETER_VAGRANTFILE_CUSTOM_CONTENT);
   }

--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/vagrant/VagrantFilePatcher.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/vagrant/VagrantFilePatcher.java
@@ -83,12 +83,17 @@ public class VagrantFilePatcher {
         final File mountRoot = context.getCheckoutDirectory();
         final String basePath = context.getCheckoutMountPoint();
 
-        final String patch = generateVagrantfile(mountRoot, basePath);
-        logger.activityStarted("generate", "Added to the end of the Vagrantfile", "vagrant");
-        logger.message(patch);
+        if (context.getRequiresCustomFile()) {
+          logger.activityStarted("generate", "Override existing Vagrantfile", "vagrant");
+          logger.message(context.getCustomVagrantfileContent());
+          writeVagrantFile(originalVagrantFile, context.getCustomVagrantfileContent());
+        } else {
+          logger.activityStarted("generate", "Added to the end of the Vagrantfile", "vagrant");
+          final String patch = generateVagrantfile(mountRoot, basePath);;
+          logger.message(patch);
+          writeVagrantFile(originalVagrantFile, text + "\n\n" + patch);
+        }
         logger.activityFinished("generate", "vagrant");
-
-        writeVagrantFile(originalVagrantFile, text + "\n\n" + patch);
 
         final String relPath = RelativePaths.resolveRelativePath(mountRoot, context.getWorkingDirectory());
         continuation.execute(basePath + (relPath.length() == 0 ? "" : "/" + relPath));

--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/vagrant/VagrantFilePatcher.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/vagrant/VagrantFilePatcher.java
@@ -44,7 +44,7 @@ public class VagrantFilePatcher {
       @Override
       protected BuildFinishedStatus waitForImpl() throws RunBuildException {
 
-        final String text;
+        String text;
         try {
           text = FileUtil.readText(originalVagrantFile);
         } catch (IOException e) {
@@ -83,16 +83,18 @@ public class VagrantFilePatcher {
         final File mountRoot = context.getCheckoutDirectory();
         final String basePath = context.getCheckoutMountPoint();
 
-        if (context.getRequiresCustomFile()) {
+        if (context.getCustomVagrantfileContent().length() > 0) {
           logger.activityStarted("generate", "Override existing Vagrantfile", "vagrant");
           logger.message(context.getCustomVagrantfileContent());
-          writeVagrantFile(originalVagrantFile, context.getCustomVagrantfileContent());
-        } else {
-          logger.activityStarted("generate", "Added to the end of the Vagrantfile", "vagrant");
-          final String patch = generateVagrantfile(mountRoot, basePath);;
-          logger.message(patch);
-          writeVagrantFile(originalVagrantFile, text + "\n\n" + patch);
+          text = context.getCustomVagrantfileContent();
         }
+
+        String patch = "";
+        logger.activityStarted("generate", "Added to the end of the Vagrantfile", "vagrant");
+        patch = patch + "\n\n" + generateVagrantfile(mountRoot, basePath);
+        logger.message(patch);
+
+        writeVagrantFile(originalVagrantFile, text + "\n\n" + patch);
         logger.activityFinished("generate", "vagrant");
 
         final String relPath = RelativePaths.resolveRelativePath(mountRoot, context.getWorkingDirectory());

--- a/common/src/com/jonnyzzz/teamcity/virtual/VMConstants.java
+++ b/common/src/com/jonnyzzz/teamcity/virtual/VMConstants.java
@@ -37,6 +37,8 @@ public class VMConstants {
 
   public static final String PARAMETER_VAGRANT_FILE = "vagrant-file";
   public static final String PARAMETER_VAGRANT_CUSTOM_COMMANDLINE = "vagrant-commandline";
+  public static final String PARAMETER_VAGRANTFILE_CUSTOM_CONTENT = "vagrantfile-content";
+  public static final String PARAMETER_VAGRANTFILE_FULL_OVERRIDE = "no";
 
   public static final String VAGRANT_FILE = "Vagrantfile";
 }

--- a/common/src/com/jonnyzzz/teamcity/virtual/VMConstants.java
+++ b/common/src/com/jonnyzzz/teamcity/virtual/VMConstants.java
@@ -38,7 +38,6 @@ public class VMConstants {
   public static final String PARAMETER_VAGRANT_FILE = "vagrant-file";
   public static final String PARAMETER_VAGRANT_CUSTOM_COMMANDLINE = "vagrant-commandline";
   public static final String PARAMETER_VAGRANTFILE_CUSTOM_CONTENT = "vagrantfile-content";
-  public static final String PARAMETER_VAGRANTFILE_FULL_OVERRIDE = "no";
 
   public static final String VAGRANT_FILE = "Vagrantfile";
 }

--- a/server/resources/vm-vagrant-edit.jsp
+++ b/server/resources/vm-vagrant-edit.jsp
@@ -38,20 +38,11 @@
 </tr>
 
 <tr class="advancedSetting">
-  <th><label for="${ctx.vagrantCustomCommandLine}">Vagrantfile patch:</label></th>
+  <th><label for="${ctx.vagrantCustomCommandLine}">Override Vagrantfile:</label></th>
   <td>
     <props:multilineProperty name="${ctx.vagrantfileCustomContent}" linkTitle="Vagrantfile content" cols="49" rows="3" expanded="${true}"
     value=""/>
-    <span class="smallNote">This is appended to the existing Vagrantfile</span>
+    <span class="smallNote">If you enter text here, the existing Vagrantfile is overridden with this string</span>
     <span id="error_${ctx.vagrantfileCustomContent}" class="error"></span>
-  </td>
-</tr>
-
-<tr class="advancedSetting">
-  <th><label for="${ctx.vagrantCustomCommandLine}">Override Vagrantfile content:</label></th>
-  <td>
-    <props:textProperty name="${ctx.vagrantfileFullOverride}" className="longField" value="no"/>
-    <span class="smallNote">Type in "yes" if you want to override the existing Vagrantfile</span>
-    <span id="error_${ctx.vagrantfileFullOverride}" class="error"></span>
   </td>
 </tr>

--- a/server/resources/vm-vagrant-edit.jsp
+++ b/server/resources/vm-vagrant-edit.jsp
@@ -31,9 +31,27 @@
 <tr class="advancedSetting">
   <th><label for="${ctx.vagrantCustomCommandLine}">Additional Vagrant Parameters:</label></th>
   <td>
-    <props:multilineProperty name="${ctx.vagrantCustomCommandLine}" linkTitle="Docker Parameters" cols="49" rows="3" expanded="${true}"/>
+    <props:multilineProperty name="${ctx.vagrantCustomCommandLine}" linkTitle="Vagrant Parameters" cols="49" rows="3" expanded="${true}"/>
     <span class="smallNote">Additional commandline parameters to the <em>vagrant up</em> command. Write each parameter on a new line</span>
     <span id="error_${ctx.vagrantCustomCommandLine}" class="error"></span>
   </td>
 </tr>
 
+<tr class="advancedSetting">
+  <th><label for="${ctx.vagrantCustomCommandLine}">Vagrantfile patch:</label></th>
+  <td>
+    <props:multilineProperty name="${ctx.vagrantfileCustomContent}" linkTitle="Vagrantfile content" cols="49" rows="3" expanded="${true}"
+    value=""/>
+    <span class="smallNote">This is appended to the existing Vagrantfile</span>
+    <span id="error_${ctx.vagrantfileCustomContent}" class="error"></span>
+  </td>
+</tr>
+
+<tr class="advancedSetting">
+  <th><label for="${ctx.vagrantCustomCommandLine}">Override Vagrantfile content:</label></th>
+  <td>
+    <props:textProperty name="${ctx.vagrantfileFullOverride}" className="longField" value="no"/>
+    <span class="smallNote">Type in "yes" if you want to override the existing Vagrantfile</span>
+    <span id="error_${ctx.vagrantfileFullOverride}" class="error"></span>
+  </td>
+</tr>

--- a/server/resources/vm-vagrant-view.jsp
+++ b/server/resources/vm-vagrant-view.jsp
@@ -24,3 +24,7 @@
 <div class="parameter">
   Additional Vagrant Parameters: <strong><props:displayValue name="${ctx.vagrantCustomCommandLine}" /></strong>
 </div>
+
+<div class="parameter">
+  Custom Vagrantfile content: <strong><props:displayValue name="${ctx.vagrantfileCustomContent}" /></strong>
+</div>

--- a/server/src/com/jonnyzzz/teamcity/virtual/FormBean.java
+++ b/server/src/com/jonnyzzz/teamcity/virtual/FormBean.java
@@ -65,6 +65,16 @@ public class FormBean {
   }
 
   @NotNull
+  public String getVagrantfileCustomContent() {
+    return PARAMETER_VAGRANTFILE_CUSTOM_CONTENT;
+  }
+
+  @NotNull
+  public String getVagrantfileFullOverride() {
+    return PARAMETER_VAGRANTFILE_FULL_OVERRIDE;
+  }
+
+  @NotNull
   public String getWorkingDirectory() {
     return AgentRuntimeProperties.BUILD_WORKING_DIR;
   }

--- a/server/src/com/jonnyzzz/teamcity/virtual/FormBean.java
+++ b/server/src/com/jonnyzzz/teamcity/virtual/FormBean.java
@@ -70,11 +70,6 @@ public class FormBean {
   }
 
   @NotNull
-  public String getVagrantfileFullOverride() {
-    return PARAMETER_VAGRANTFILE_FULL_OVERRIDE;
-  }
-
-  @NotNull
   public String getWorkingDirectory() {
     return AgentRuntimeProperties.BUILD_WORKING_DIR;
   }


### PR DESCRIPTION
This pull requests adds the ability to override the Vagrantfile either with a totally custom value, or then just modify the patch that is added to the Vagrantfile.

It does not modify default behavior, so backwards compatibility should be ok.