### PR TITLE
fixes #30 (better default shell), improves custom vagrantfile options

### DIFF
--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/VMRunnerContext.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/VMRunnerContext.java
@@ -74,6 +74,10 @@ public class VMRunnerContext {
 
   @NotNull
   public String getShellLocation() {
-    return myContext.getRunnerParameters().get(VMConstants.PARAMETER_SHELL);
+    String loc = myContext.getRunnerParameters().get(VMConstants.PARAMETER_SHELL);
+    if (loc == null) {
+      return "/bin/bash";
+    }
+    return loc;
   }
 }

--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/VMRunnerContext.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/VMRunnerContext.java
@@ -71,4 +71,9 @@ public class VMRunnerContext {
     String mountPoint = myContext.getRunnerParameters().get(VMConstants.PARAMETER_CHECKOUT_MOUNT_POINT);
     return StringUtil.isEmptyOrSpaces(mountPoint) ? "/checkout" : mountPoint;
   }
+
+  @NotNull
+  public String getShellLocation() {
+    return myContext.getRunnerParameters().get(VMConstants.PARAMETER_SHELL);
+  }
 }

--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/docker/DockerVM.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/docker/DockerVM.java
@@ -88,7 +88,7 @@ public class DockerVM extends BaseVM implements VMRunner {
         );
 
         builder.addTryProcess(
-                block("Executing the command", cmd.commandline(
+                block("Executing the command using " + ctx.getShellLocation(), cmd.commandline(
                         checkoutDir,
                         dockerRun(name, workDir, additionalCommands, scriptRun(script))
                 ))
@@ -114,7 +114,7 @@ public class DockerVM extends BaseVM implements VMRunner {
                     checkoutDir,  /** chown should be called for checkout dir to make sure all file owners are fixed, no matter what workdir is **/
                     Arrays.<String>asList(),
                     Arrays.asList(
-                            "/bin/bash",                           //TODO: bash
+                            ctx.getShellLocation(),
                             "-c",
                             "chown -R " + uid + ":" + gid + " ."
                     ))));
@@ -127,7 +127,7 @@ public class DockerVM extends BaseVM implements VMRunner {
       @NotNull
       private List<String> scriptRun(@NotNull final File script) {
         return Arrays.asList(
-                "/bin/bash",  ///TODO: imagine OS without bash
+                ctx.getShellLocation(),
                 "-c",
                 "\"source " + script.getName() + "\""
         );

--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/vagrant/VagrantContext.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/vagrant/VagrantContext.java
@@ -60,6 +60,14 @@ public class VagrantContext extends VMRunnerContext {
 
   @NotNull
   public String getCustomVagrantfileContent() {
-    return myContext.getRunnerParameters().get(VMConstants.PARAMETER_VAGRANTFILE_CUSTOM_CONTENT);
+    String r = myContext.getRunnerParameters().get(VMConstants.PARAMETER_VAGRANTFILE_CUSTOM_CONTENT);
+    if (r == null || isTrue(myContext.getRunnerParameters().get(VMConstants.PARAMETER_VAGRANTFILE_DO_OVERRIDE))) {
+      return "";
+    }
+    return r;
+  }
+
+  private boolean isTrue(String property) {
+    return !Boolean.parseBoolean(property) && !"yes".equalsIgnoreCase(property);
   }
 }

--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/vagrant/VagrantVM.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/vagrant/VagrantVM.java
@@ -101,8 +101,21 @@ public class VagrantVM extends BaseVM implements VMRunner {
             //TODO: not clear how workdir maps into VM path for Vagrant as we use Vagrantfile for that
             //TODO: fix windows case here ( bash => parameters ), slashes
             builder.addTryProcess(
-                    block("Running the script",
-                            cmd.commandline(workDir, Arrays.asList("vagrant", "ssh", "-c", "\"/bin/bash -c 'cd " + relativePath + " && . " + script.getName() + "'\"")))
+                    block("Running the script using " + ctx.getShellLocation(),
+                            cmd.commandline(
+                                    workDir,
+                                    Arrays.asList(
+                                            "vagrant",
+                                            "ssh",
+                                            "-c",
+                                            "\""
+                                                    + ctx.getShellLocation()
+                                                    + " -c 'cd "
+                                                    + relativePath
+                                                    + " && . " + script.getName() + "'\""
+                                    )
+                            ))
+
             );
           }
 

--- a/common/src/com/jonnyzzz/teamcity/virtual/VMConstants.java
+++ b/common/src/com/jonnyzzz/teamcity/virtual/VMConstants.java
@@ -31,6 +31,7 @@ public class VMConstants {
   public static final String VM_VAGRANT = "vagrant";
   public static final String PARAMETER_SCRIPT = "script";
   public static final String PARAMETER_CHECKOUT_MOUNT_POINT = "checkout-mount-point";
+  public static final String PARAMETER_SHELL = "default-shell-location";
 
   public static final String PARAMETER_DOCKER_IMAGE_NAME = "docker-image-name";
   public static final String PARAMETER_DOCKER_CUSTOM_COMMANDLINE = "docker-commandline";
@@ -38,6 +39,7 @@ public class VMConstants {
   public static final String PARAMETER_VAGRANT_FILE = "vagrant-file";
   public static final String PARAMETER_VAGRANT_CUSTOM_COMMANDLINE = "vagrant-commandline";
   public static final String PARAMETER_VAGRANTFILE_CUSTOM_CONTENT = "vagrantfile-content";
+  public static final String PARAMETER_VAGRANTFILE_DO_OVERRIDE = "vagrantfile-do-override";
 
   public static final String VAGRANT_FILE = "Vagrantfile";
 }

--- a/server/resources/vm-edit.jsp
+++ b/server/resources/vm-edit.jsp
@@ -14,7 +14,7 @@
   ~ limitations under the License.
   --%>
 
-<%@ include file="/include-internal.jsp"%>
+<%@ include file="/include-internal.jsp" %>
 <jsp:useBean id="ctx" class="com.jonnyzzz.teamcity.virtual.FormBean"/>
 
 <c:set var="note">
@@ -25,7 +25,7 @@
   <props:selectSectionProperty name="${ctx.vm}" title="Virtualization" note="${note}">
     <c:forEach var="it" items="${ctx.vms}">
       <props:selectSectionPropertyContent value="${it.name}" caption="${it.caption}">
-        <jsp:include page="${it.edit}" />
+        <jsp:include page="${it.edit}"/>
       </props:selectSectionPropertyContent>
     </c:forEach>
   </props:selectSectionProperty>
@@ -36,8 +36,19 @@
       <props:textProperty name="${ctx.checkoutMountPoint}" className="longField"/>
       <span class="error" id="error:${ctx.checkoutMountPoint}"></span>
       <span class="smallNote">
-        Path on the Virtual Machine to mount the <em>build checkout directory<bs:help file="Build+Checkout+Directory"/></em>
+        Path on the Virtual Machine to mount the <em>build checkout directory<bs:help
+              file="Build+Checkout+Directory"/></em>
       </span>
+    </td>
+  </tr>
+
+  <tr class="advancedSetting">
+    <th><label for="${ctx.shellSelection}">Select default shell to use</label></th>
+    <td>
+      <props:selectProperty name="${ctx.shellSelection}">
+        <props:option value="/bin/bash">/bin/bash</props:option>
+        <props:option value="/bin/sh">/bin/sh</props:option>
+      </props:selectProperty>
     </td>
   </tr>
 </l:settingsGroup>
@@ -49,7 +60,7 @@
       <span class="smallNote">
         Virtual environment is started with
         the <em>build checkout directory <bs:help file="Build+Checkout+Directory"/></em> mounted for read/write into the virtual environment.
-        <br />
+        <br/>
         The <em>working directory path</em> and the <em>build checkout directory path</em> are automatically mapped into virtual environment paths.
         <br/>
         The virtual environment is destroyed after execution is completed
@@ -59,7 +70,8 @@
   <tr>
     <th>Command:</th>
     <td>
-      <props:multilineProperty name="${ctx.script}" linkTitle="Script to run in the VM" cols="49" rows="8" expanded="${true}"/>
+      <props:multilineProperty name="${ctx.script}" linkTitle="Script to run in the VM" cols="49" rows="8"
+                               expanded="${true}"/>
       <span class="error" id="error:${ctx.script}"></span>
       <span class="smallNote">
         Commands to be executed in the virtual environment in the <em>working directory</em>
@@ -69,10 +81,10 @@
 
   <tr>
     <th>
-      <label for="${ctx.workingDirectory}">Working Directory: <bs:help file="Build+Working+Directory" /></label>
+      <label for="${ctx.workingDirectory}">Working Directory: <bs:help file="Build+Working+Directory"/></label>
     </th>
     <td>
-      <props:textProperty name="${ctx.workingDirectory}"  className="longField"/>
+      <props:textProperty name="${ctx.workingDirectory}" className="longField"/>
       <bs:vcsTree fieldId="${ctx.workingDirectory}" treeId="teamcity-build-workingDir" dirsOnly="true"/>
       <span class="smallNote">
         The <em>relative path</em> to the <em>build checkout directory <bs:help file="Build+Checkout+Directory"/></em>

--- a/server/resources/vm-vagrant-edit.jsp
+++ b/server/resources/vm-vagrant-edit.jsp
@@ -40,8 +40,10 @@
 <tr class="advancedSetting">
   <th><label for="${ctx.vagrantCustomCommandLine}">Override Vagrantfile:</label></th>
   <td>
-    <props:multilineProperty name="${ctx.vagrantfileCustomContent}" linkTitle="Vagrantfile content" cols="49" rows="3" expanded="${true}"
-    value=""/>
+    <props:checkboxProperty name="${ctx.vagrantfileDoOverride}" value="yes" uncheckedValue="no" />
+    <label for="${ctx.vagrantfileDoOverride}">Do override Vagrantfile with custom content</label>
+    <props:multilineProperty name="${ctx.vagrantfileCustomContent}" linkTitle="Vagrantfile content" cols="49" rows="3"
+                             expanded="${true}" value=""/>
     <span class="smallNote">If you enter text here, the existing Vagrantfile is overridden with this string</span>
     <span id="error_${ctx.vagrantfileCustomContent}" class="error"></span>
   </td>

--- a/server/src/com/jonnyzzz/teamcity/virtual/FormBean.java
+++ b/server/src/com/jonnyzzz/teamcity/virtual/FormBean.java
@@ -50,6 +50,11 @@ public class FormBean {
   }
 
   @NotNull
+  public String getShellSelection() {
+    return PARAMETER_SHELL;
+  }
+
+  @NotNull
   public String getDockerCustomCommandLine() {
     return PARAMETER_DOCKER_CUSTOM_COMMANDLINE;
   }
@@ -67,6 +72,11 @@ public class FormBean {
   @NotNull
   public String getVagrantfileCustomContent() {
     return PARAMETER_VAGRANTFILE_CUSTOM_CONTENT;
+  }
+
+  @NotNull
+  public String getVagrantfileDoOverride() {
+    return PARAMETER_VAGRANTFILE_DO_OVERRIDE;
   }
 
   @NotNull


### PR DESCRIPTION
This improves the custom Vagrantfile option by adding a checkbox to disable/enable the option at all (see issue #35). Additionally, it adds a select box to allow default shell selection. There is either /bin/sh and /bin/bash available (see issue #30).

It might get some problems when updating the plug-in with existing configuration. They probably should be "upgraded" somehow (e.g. just by opening and saving them).