### PR TITLE
Add the ability to select which docker mount mode you wish to use.

### DIFF
--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/VMRunnerContext.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/VMRunnerContext.java
@@ -80,4 +80,13 @@ public class VMRunnerContext {
     }
     return loc;
   }
+
+  @NotNull
+  public String getDockerMountMode() {
+    String mountMode = myContext.getRunnerParameters().get(VMConstants.DOCKER_MOUNT_MODE);
+    if (mountMode == null) {
+      return "rw";
+    }
+    return mountMode;
+  }
 }

--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/docker/DockerVM.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/docker/DockerVM.java
@@ -146,7 +146,7 @@ public class DockerVM extends BaseVM implements VMRunner {
                 "--rm=true",
                 "--name=" + name,
                 "-v",
-                checkoutDir.getPath() + ":" + mountPoint + ":rw",
+                checkoutDir.getPath() + ":" + mountPoint + ":" + ctx.getDockerMountMode(),
                 "--workdir=" + mountPoint + "/" + RelativePaths.resolveRelativePath(checkoutDir, workDir),
                 "--interactive=false",
                 "--tty=false"));

--- a/common/src/com/jonnyzzz/teamcity/virtual/VMConstants.java
+++ b/common/src/com/jonnyzzz/teamcity/virtual/VMConstants.java
@@ -32,6 +32,7 @@ public class VMConstants {
   public static final String PARAMETER_SCRIPT = "script";
   public static final String PARAMETER_CHECKOUT_MOUNT_POINT = "checkout-mount-point";
   public static final String PARAMETER_SHELL = "default-shell-location";
+  public static final String DOCKER_MOUNT_MODE = "docker-mount-mode";
 
   public static final String PARAMETER_DOCKER_IMAGE_NAME = "docker-image-name";
   public static final String PARAMETER_DOCKER_CUSTOM_COMMANDLINE = "docker-commandline";

--- a/server/resources/vm-docker-edit.jsp
+++ b/server/resources/vm-docker-edit.jsp
@@ -34,6 +34,18 @@
 </tr>
 
 <tr class="advancedSetting">
+  <th><label for="${ctx.mountMode}">Select mount mode to use:</label></th>
+  <td>
+    <props:selectProperty name="${ctx.mountMode}">
+      <props:option value="rw">read-write (RW)</props:option>
+      <props:option value="ro">read-only (RO)</props:option>
+      <props:option value="z">shared volume label (z)</props:option>
+      <props:option value="Z">private unshared volume label (Z)</props:option>
+    </props:selectProperty>
+  </td>
+</tr>
+
+<tr class="advancedSetting">
   <th><label for="${ctx.dockerCustomCommandLine}">Additional Docker Parameters:</label></th>
   <td>
     <props:multilineProperty name="${ctx.dockerCustomCommandLine}" linkTitle="Docker Parameters" cols="49" rows="3" expanded="${true}"/>

--- a/server/src/com/jonnyzzz/teamcity/virtual/FormBean.java
+++ b/server/src/com/jonnyzzz/teamcity/virtual/FormBean.java
@@ -45,6 +45,11 @@ public class FormBean {
   }
 
   @NotNull
+  public String getMountMode() {
+    return DOCKER_MOUNT_MODE;
+  }
+
+  @NotNull
   public String getDockerImageName() {
     return PARAMETER_DOCKER_IMAGE_NAME;
   }


### PR DESCRIPTION
This small pull request adds the ability of selecting which docker mount mode to use, defaulting to rw which covers most users requirements, but also providing z|Z for SELinux scenarios.

With the options of:
- read-write RW (default)
- read-only RO
- shared volume label z
- private unshared volume label Z