### PR TITLE
Windows containers support

### DIFF
--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/RelativePaths.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/RelativePaths.java
@@ -16,6 +16,7 @@
 
 package com.jonnyzzz.teamcity.virtual.run;
 
+import com.intellij.openapi.util.SystemInfo;
 import jetbrains.buildServer.util.FileUtil;
 import org.jetbrains.annotations.NotNull;
 
@@ -26,13 +27,23 @@ import java.io.File;
  */
 public class RelativePaths {
   @NotNull
-  public static String resolveRelativePath(@NotNull final File baseDir, @NotNull final File path) {
-    String result = FileUtil.getRelativePath(baseDir, path);
+  public static String resolveRelativePath(@NotNull final File baseDir, @NotNull final File path, boolean isWindows, boolean convertToLinux) {
+    String result = isWindows
+            ? FileUtil.getRelativePath(baseDir.getAbsolutePath(), path.getAbsolutePath(), '\\')
+            : FileUtil.getRelativePath(baseDir.getAbsolutePath(), path.getAbsolutePath(), '/');
     if (result == null) return "";
-
-    result = result.replace('\\', '/');
-
-    while (result.endsWith(".") || result.endsWith("/")) result = result.substring(0, result.length() - 1);
+    if(convertToLinux)
+      result = result.replace('\\', '/');
+    if(isWindows) {
+      while (result.endsWith(".") || result.endsWith("\\")) result = result.substring(0, result.length() - 1);
+    } else {
+      while (result.endsWith(".") || result.endsWith("/")) result = result.substring(0, result.length() - 1);
+    }
     return result;
+  }
+
+  @NotNull
+  public static String resolveRelativePath(@NotNull final File baseDir, @NotNull final File path) {
+    return resolveRelativePath(baseDir, path, SystemInfo.isWindows, true);
   }
 }

--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/VMRunnerContext.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/VMRunnerContext.java
@@ -16,6 +16,7 @@
 
 package com.jonnyzzz.teamcity.virtual.run;
 
+import com.intellij.openapi.util.SystemInfo;
 import com.jonnyzzz.teamcity.virtual.VMConstants;
 import jetbrains.buildServer.RunBuildException;
 import jetbrains.buildServer.agent.BuildRunnerContext;
@@ -68,14 +69,20 @@ public class VMRunnerContext {
 
   @NotNull
   public String getCheckoutMountPoint() {
+    String defaultMountPoint;
+    if(SystemInfo.isUnix) {
+      defaultMountPoint = "/checkout";
+    } else {
+      defaultMountPoint = "C:\\checkout";
+    }
     String mountPoint = myContext.getRunnerParameters().get(VMConstants.PARAMETER_CHECKOUT_MOUNT_POINT);
-    return StringUtil.isEmptyOrSpaces(mountPoint) ? "/checkout" : mountPoint;
+    return StringUtil.isEmptyOrSpaces(mountPoint) ? defaultMountPoint : mountPoint;
   }
 
   @NotNull
   public String getShellLocation() {
     String loc = myContext.getRunnerParameters().get(VMConstants.PARAMETER_SHELL);
-    if (loc == null) {
+    if (loc.equals("default")) {
       return "/bin/bash";
     }
     return loc;

--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/VMRunnerContext.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/VMRunnerContext.java
@@ -69,19 +69,14 @@ public class VMRunnerContext {
 
   @NotNull
   public String getCheckoutMountPoint() {
-    String defaultMountPoint;
-    if(SystemInfo.isUnix) {
-      defaultMountPoint = "/checkout";
-    } else {
-      defaultMountPoint = "C:\\checkout";
-    }
+    final String defaultMountPoint = SystemInfo.isUnix ? "/checkout" : "C:\\checkout";
     String mountPoint = myContext.getRunnerParameters().get(VMConstants.PARAMETER_CHECKOUT_MOUNT_POINT);
     return StringUtil.isEmptyOrSpaces(mountPoint) ? defaultMountPoint : mountPoint;
   }
 
   @NotNull
   public String getShellLocation() {
-    String loc = myContext.getRunnerParameters().get(VMConstants.PARAMETER_SHELL);
+    final String loc = myContext.getRunnerParameters().get(VMConstants.PARAMETER_SHELL);
     if (loc.equals("default")) {
       return "/bin/bash";
     }
@@ -90,7 +85,7 @@ public class VMRunnerContext {
 
   @NotNull
   public String getDockerMountMode() {
-    String mountMode = myContext.getRunnerParameters().get(VMConstants.DOCKER_MOUNT_MODE);
+    final String mountMode = myContext.getRunnerParameters().get(VMConstants.DOCKER_MOUNT_MODE);
     if (mountMode == null) {
       return "rw";
     }

--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/docker/DockerContext.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/docker/DockerContext.java
@@ -16,12 +16,17 @@
 
 package com.jonnyzzz.teamcity.virtual.run.docker;
 
+import com.intellij.openapi.util.SystemInfo;
 import com.jonnyzzz.teamcity.virtual.VMConstants;
 import com.jonnyzzz.teamcity.virtual.run.VMRunnerContext;
+import com.oracle.tools.packager.Log;
 import jetbrains.buildServer.RunBuildException;
 import jetbrains.buildServer.agent.BuildRunnerContext;
 import jetbrains.buildServer.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * @author Eugene Petrenko (eugene.petrenko@gmail.com)
@@ -36,5 +41,33 @@ public class DockerContext extends VMRunnerContext {
     final String image = myContext.getRunnerParameters().get(VMConstants.PARAMETER_DOCKER_IMAGE_NAME);
     if (StringUtil.isEmptyOrSpaces(image)) throw new RunBuildException("Docker image is not specified");
     return image;
+  }
+
+  public boolean isDockerServerWindowsBased() throws RunBuildException {
+    final String serverArch = myContext.getConfigParameters().get(VMConstants.DOCKER_SERVER_OS_ARCH_PROPERTY);
+    return serverArch.equals("windows/amd64");
+  }
+
+  @NotNull
+  public String getShellLocationInsideContainer() throws RunBuildException {
+    String defaultShellLocation;
+    if(isDockerServerWindowsBased()) {
+      defaultShellLocation = "cmd.exe";
+    } else {
+      defaultShellLocation = "/bin/bash";
+    }
+    String loc = myContext.getRunnerParameters().get(VMConstants.PARAMETER_SHELL);
+    if (loc.equals("default")) {
+      return defaultShellLocation;
+    }
+    return loc;
+  }
+
+  public String getPathSeparatorInsideContainer() throws RunBuildException {
+    if(isDockerServerWindowsBased()) {
+      return "\\";
+    } else {
+      return "/";
+    }
   }
 }

--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/docker/DockerContext.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/docker/DockerContext.java
@@ -53,6 +53,13 @@ public class DockerContext extends VMRunnerContext {
     return loc;
   }
 
+  @NotNull
+  public String getCheckoutMountPointInsideContainer() throws RunBuildException {
+    final String defaultMountPoint = isDockerServerWindowsBased() ? "C:\\checkout" : "/checkout";
+    final String mountPoint = myContext.getRunnerParameters().get(VMConstants.PARAMETER_CHECKOUT_MOUNT_POINT);
+    return StringUtil.isEmptyOrSpaces(mountPoint) ? defaultMountPoint : mountPoint;
+  }
+
   public String getPathSeparatorInsideContainer() throws RunBuildException {
     return isDockerServerWindowsBased() ? "\\" : "/";
   }

--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/docker/DockerContext.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/docker/DockerContext.java
@@ -16,17 +16,12 @@
 
 package com.jonnyzzz.teamcity.virtual.run.docker;
 
-import com.intellij.openapi.util.SystemInfo;
 import com.jonnyzzz.teamcity.virtual.VMConstants;
 import com.jonnyzzz.teamcity.virtual.run.VMRunnerContext;
-import com.oracle.tools.packager.Log;
 import jetbrains.buildServer.RunBuildException;
 import jetbrains.buildServer.agent.BuildRunnerContext;
 import jetbrains.buildServer.util.StringUtil;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.Arrays;
-import java.util.List;
 
 /**
  * @author Eugene Petrenko (eugene.petrenko@gmail.com)
@@ -44,19 +39,14 @@ public class DockerContext extends VMRunnerContext {
   }
 
   public boolean isDockerServerWindowsBased() throws RunBuildException {
-    final String serverArch = myContext.getConfigParameters().get(VMConstants.DOCKER_SERVER_OS_ARCH_PROPERTY);
-    return serverArch.equals("windows/amd64");
+    final String serverArch = myContext.getConfigParameters().get(VMConstants.DOCKER_HOST_OS_PROPERTY);
+    return serverArch.equals("windows");
   }
 
   @NotNull
   public String getShellLocationInsideContainer() throws RunBuildException {
-    String defaultShellLocation;
-    if(isDockerServerWindowsBased()) {
-      defaultShellLocation = "cmd.exe";
-    } else {
-      defaultShellLocation = "/bin/bash";
-    }
-    String loc = myContext.getRunnerParameters().get(VMConstants.PARAMETER_SHELL);
+    final String defaultShellLocation = isDockerServerWindowsBased() ? "cmd.exe" : "/bin/bash";
+    final String loc = myContext.getRunnerParameters().get(VMConstants.PARAMETER_SHELL);
     if (loc.equals("default")) {
       return defaultShellLocation;
     }
@@ -64,10 +54,6 @@ public class DockerContext extends VMRunnerContext {
   }
 
   public String getPathSeparatorInsideContainer() throws RunBuildException {
-    if(isDockerServerWindowsBased()) {
-      return "\\";
-    } else {
-      return "/";
-    }
+    return isDockerServerWindowsBased() ? "\\" : "/";
   }
 }

--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/docker/DockerVM.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/docker/DockerVM.java
@@ -35,7 +35,6 @@ import org.jetbrains.annotations.NotNull;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import static com.jonnyzzz.teamcity.virtual.run.CommandLineUtils.additionalCommands;
@@ -162,7 +161,7 @@ public class DockerVM extends BaseVM implements VMRunner {
                 "--name=" + name,
                 "-v",
                 checkoutDir.getPath() + ":" + mountPoint + ":" + ctx.getDockerMountMode(),
-                "--workdir=" + mountPoint + ctx.getPathSeparatorInsideContainer() + RelativePaths.resolveRelativePath(checkoutDir, workDir),
+                "--workdir=" + mountPoint + ctx.getPathSeparatorInsideContainer() + RelativePaths.resolveRelativePath(checkoutDir, workDir, ctx.isDockerServerWindowsBased(), false),
                 "--interactive=false",
                 "--tty=false"));
 

--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/docker/DockerVM.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/docker/DockerVM.java
@@ -73,7 +73,7 @@ public class DockerVM extends BaseVM implements VMRunner {
 
     final File checkoutDir = ctx.getCheckoutDirectory();
     final File workDir = ctx.getWorkingDirectory();
-    final String mountPoint = ctx.getCheckoutMountPoint();
+    final String mountPoint = ctx.getCheckoutMountPointInsideContainer();
     final BuildProgressLogger logger = context.getBuild().getBuildLogger();
 
     myScriptFile.generateScriptFile(ctx, builder, new ScriptFile.Builder() {

--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/docker/UserUIDAndGIDImpl.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/docker/UserUIDAndGIDImpl.java
@@ -46,10 +46,8 @@ public class UserUIDAndGIDImpl implements UserUIDAndGID {
       public void afterAgentConfigurationLoaded(@NotNull final BuildAgent agent) {
         final BuildAgentConfiguration configuration = agent.getConfiguration();
 
-        if (configuration.getConfigurationParameters().get(VMConstants.DOCKER_CLIENT_VERSION_PROPERTY) == null) return;
-        if (configuration.getConfigurationParameters().get(VMConstants.DOCKER_CLIENT_OS_ARCH_PROPERTY) == null) return;
-        if (configuration.getConfigurationParameters().get(VMConstants.DOCKER_SERVER_OS_ARCH_PROPERTY) == null) return;
-        if (configuration.getConfigurationParameters().get(VMConstants.DOCKER_SERVER_VERSION_PROPERTY) == null) return;
+        if (configuration.getConfigurationParameters().get(VMConstants.DOCKER_HOST_OS_PROPERTY) == null) return;
+        if (configuration.getConfigurationParameters().get(VMConstants.DOCKER_PROPERTY) == null) return;
         if (!configuration.getSystemInfo().isUnix()) return;
         if (configuration.getSystemInfo().isWindows()) return;
         if (configuration.getSystemInfo().isMac()) return;

--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/docker/UserUIDAndGIDImpl.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/docker/UserUIDAndGIDImpl.java
@@ -46,7 +46,10 @@ public class UserUIDAndGIDImpl implements UserUIDAndGID {
       public void afterAgentConfigurationLoaded(@NotNull final BuildAgent agent) {
         final BuildAgentConfiguration configuration = agent.getConfiguration();
 
-        if (configuration.getConfigurationParameters().get(VMConstants.DOCKER_PROPERTY) == null) return;
+        if (configuration.getConfigurationParameters().get(VMConstants.DOCKER_CLIENT_VERSION_PROPERTY) == null) return;
+        if (configuration.getConfigurationParameters().get(VMConstants.DOCKER_CLIENT_OS_ARCH_PROPERTY) == null) return;
+        if (configuration.getConfigurationParameters().get(VMConstants.DOCKER_SERVER_OS_ARCH_PROPERTY) == null) return;
+        if (configuration.getConfigurationParameters().get(VMConstants.DOCKER_SERVER_VERSION_PROPERTY) == null) return;
         if (!configuration.getSystemInfo().isUnix()) return;
         if (configuration.getSystemInfo().isWindows()) return;
         if (configuration.getSystemInfo().isMac()) return;

--- a/common/src/com/jonnyzzz/teamcity/virtual/VMConstants.java
+++ b/common/src/com/jonnyzzz/teamcity/virtual/VMConstants.java
@@ -24,6 +24,10 @@ public class VMConstants {
 
   public static final String VAGRANT_PROPERTY = "vagrant";
   public static final String DOCKER_PROPERTY = "docker";
+  public static final String DOCKER_CLIENT_VERSION_PROPERTY = "docker.client.version";
+  public static final String DOCKER_CLIENT_OS_ARCH_PROPERTY = "docker.client.os.arch";
+  public static final String DOCKER_SERVER_VERSION_PROPERTY = "docker.server.version";
+  public static final String DOCKER_SERVER_OS_ARCH_PROPERTY = "docker.server.os.arch";
 
 
   public static final String PARAMETER_VM = "vm";

--- a/common/src/com/jonnyzzz/teamcity/virtual/VMConstants.java
+++ b/common/src/com/jonnyzzz/teamcity/virtual/VMConstants.java
@@ -24,11 +24,7 @@ public class VMConstants {
 
   public static final String VAGRANT_PROPERTY = "vagrant";
   public static final String DOCKER_PROPERTY = "docker";
-  public static final String DOCKER_CLIENT_VERSION_PROPERTY = "docker.client.version";
-  public static final String DOCKER_CLIENT_OS_ARCH_PROPERTY = "docker.client.os.arch";
-  public static final String DOCKER_SERVER_VERSION_PROPERTY = "docker.server.version";
-  public static final String DOCKER_SERVER_OS_ARCH_PROPERTY = "docker.server.os.arch";
-
+  public static final String DOCKER_HOST_OS_PROPERTY = "docker.host.os";
 
   public static final String PARAMETER_VM = "vm";
   public static final String VM_DOCKER = "docker";

--- a/server/resources/vm-edit.jsp
+++ b/server/resources/vm-edit.jsp
@@ -46,9 +46,15 @@
     <th><label for="${ctx.shellSelection}">Select default shell to use</label></th>
     <td>
       <props:selectProperty name="${ctx.shellSelection}">
+        <props:option value="default">default</props:option>
+        <props:option value="cmd.exe">cmd.exe</props:option>
+        <props:option value="powershell.exe">powershell.exe</props:option>
         <props:option value="/bin/bash">/bin/bash</props:option>
         <props:option value="/bin/sh">/bin/sh</props:option>
       </props:selectProperty>
+      <span class="smallNote">
+        Defaults are cmd.exe and /bin/bash
+      </span>
     </td>
   </tr>
 </l:settingsGroup>

--- a/server/resources/vm-edit.jsp
+++ b/server/resources/vm-edit.jsp
@@ -48,7 +48,6 @@
       <props:selectProperty name="${ctx.shellSelection}">
         <props:option value="default">default</props:option>
         <props:option value="cmd.exe">cmd.exe</props:option>
-        <props:option value="powershell.exe">powershell.exe</props:option>
         <props:option value="/bin/bash">/bin/bash</props:option>
         <props:option value="/bin/sh">/bin/sh</props:option>
       </props:selectProperty>


### PR DESCRIPTION
- [x] New parameters in agent configuration:
docker.client.version
docker.client.os.arch
docker.server.version
docker.server.os.arch
I saved `docker` parameter for backward compatibility.
- [x] New shells `cmd.exe` and `powershell.exe`
- [x] Detection windows based containers 
- [x] Chown in windows based containers 
- [ ] Testing vagrant for regressions 
- [x] Testing in Windows server 2016 windows containers
- [x] Testing in Windows server 2016 linux containers
~~- [ ] Testing in Windows server hyper-v containers~~ (Outside of this pull request)
- [x] Testing in Windows 10 windows containers
- [x] Testing in Windows 10 linux containers
- [x] Testing in Docker for Mac
- [x] Testing in Ubuntu for regressions 