### PR TITLE
Replace 'source' with '.' for better shell compatibility

### DIFF
--- a/agent/src/com/jonnyzzz/teamcity/virtual/run/docker/DockerVM.java
+++ b/agent/src/com/jonnyzzz/teamcity/virtual/run/docker/DockerVM.java
@@ -129,7 +129,7 @@ public class DockerVM extends BaseVM implements VMRunner {
         return Arrays.asList(
                 ctx.getShellLocation(),
                 "-c",
-                "\"source " + script.getName() + "\""
+                "\". ./" + script.getName() + "\""
         );
       }
 


### PR DESCRIPTION
This PR replaces `source` command which is a bash extension with a more compatible `.` (POSIX standard). `.` also requires `./` before file name if it's relative.